### PR TITLE
Problem: Setting topics was confusing and overly complicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,8 @@ if $parsesuccess == "OK" then {
 	import "github.com/digitalocean/logtalez"
 
 	func main() {
-		zmqconns := "tcp://127.0.0.1:24444,tcp://example.com:24444"
-		endpoints := logtalez.MakeEndpointList(zmqconns)
-
-		hosts := "host1,host2,host3"
-		programs := "nginx"
-		topics := logtalez.MakeTopicList(hosts, programs)
+		endpoints := []string{"tcp://127.0.0.1:24444,tcp://example.com:24444"}
+		topics = []string{"host1.nginx","host2.nginx","host3.nginx"}
 
 		serverCert := "/home/me/.curve/server_public_cert"
 		clientCert := "/home/me/.curve/client_public_cert"

--- a/cmd/logtalez/main.go
+++ b/cmd/logtalez/main.go
@@ -14,8 +14,7 @@ import (
 func main() {
 
 	endpointsPtr := flag.String("endpoints", "", "comma delimited list of zeromq endpoints")
-	hostsPtr := flag.String("hosts", "", "comma delimited list of hostnames to get logs from")
-	programsPtr := flag.String("programs", "", "comma delimited list of programs to get logs from")
+	topicsPtr := flag.String("topics", "", "comma delimited list of topics to subscribe to")
 	serverCertPathPtr := flag.String("servercertpath", "", "path to server public cert")
 	clientCertPathPtr := flag.String("clientcertpath", "", "path to client public cert")
 	jSONPtr := flag.Bool("json", false, "restrict output to valid JSON")
@@ -42,8 +41,8 @@ func main() {
 		log.Fatalf("error reading client certificate %q: %s", *clientCertPathPtr, err)
 	}
 
-	topicList := logtalez.MakeTopicList(*hostsPtr, *programsPtr)
-	endpointList := logtalez.MakeEndpointList(*endpointsPtr)
+	topicList := logtalez.MakeList(*topicPtr)
+	endpointList := logtalez.MakeList(*endpointsPtr)
 
 	lt, err := logtalez.New(endpointList, topicList, *serverCertPathPtr, *clientCertPathPtr)
 	if err != nil {

--- a/cmd/logtalez/main.go
+++ b/cmd/logtalez/main.go
@@ -41,8 +41,15 @@ func main() {
 		log.Fatalf("error reading client certificate %q: %s", *clientCertPathPtr, err)
 	}
 
-	topicList := logtalez.MakeList(*topicPtr)
-	endpointList := logtalez.MakeList(*endpointsPtr)
+	topicList := make([]string, 0)
+	for _, t := range strings.Split(*topicsPtr, ",") {
+		topicList = append(topicList, t)
+	}
+
+	endpointList := make([]string, 0)
+	for _, e := range strings.Split(*endpointsPtr, ",") {
+		endpointList = append(endpointList, e)
+	}
 
 	lt, err := logtalez.New(endpointList, topicList, *serverCertPathPtr, *clientCertPathPtr)
 	if err != nil {

--- a/logtalez.go
+++ b/logtalez.go
@@ -1,11 +1,6 @@
 package logtalez
 
-import (
-	"fmt"
-	"strings"
-
-	"github.com/zeromq/goczmq"
-)
+import "github.com/zeromq/goczmq"
 
 // LogTalez holds the context for a running LogTalez instance
 type LogTalez struct {
@@ -14,41 +9,6 @@ type LogTalez struct {
 	serverCert *goczmq.Cert
 	clientCert *goczmq.Cert
 	sock       *goczmq.Sock
-}
-
-// MakeTopicList is a convenience function that, given a string of comma delimited
-// hosts and a string of comma delimited program name tags, generates a slice of
-// subscription topics.
-func MakeTopicList(hosts, programs string) []string {
-	topicList := make([]string, 0)
-
-	if hosts != "" {
-		for _, h := range strings.Split(hosts, ",") {
-			if programs != "" {
-				for _, p := range strings.Split(programs, ",") {
-					topicList = append(topicList, fmt.Sprintf("%s.%s", h, p))
-				}
-			} else {
-				topicList = append(topicList, h)
-			}
-		}
-	} else {
-		topicList = append(topicList, "")
-	}
-
-	return topicList
-}
-
-// MakeEndpointList is a convenience function that, given a list of comma delimited
-// zeromq endpoints, returns a slice containing the endpoints.
-func MakeEndpointList(endpoints string) []string {
-	endpointList := make([]string, 0)
-
-	for _, e := range strings.Split(endpoints, ",") {
-		endpointList = append(endpointList, e)
-	}
-
-	return endpointList
 }
 
 // New returns a new running LogTalez instance given a slice of endpoints,

--- a/logtalez_test.go
+++ b/logtalez_test.go
@@ -9,41 +9,6 @@ import (
 	"github.com/zeromq/goczmq"
 )
 
-func TestMakeTopicList(t *testing.T) {
-	hosts := "host1,host2"
-	programs := "program1,program2"
-	topics := MakeTopicList(hosts, programs)
-
-	expected := []string{
-		"host1.program1",
-		"host1.program2",
-		"host2.program1",
-		"host2.program2",
-	}
-
-	for i, expect := range expected {
-		if topics[i] != expect {
-			t.Errorf("expected topic '%s', got '%s'", expect[i], topics[i])
-		}
-	}
-}
-
-func TestMakeEndpointList(t *testing.T) {
-	conns := "tcp://incproc1,tcp://inproc2"
-	endpoints := MakeEndpointList(conns)
-
-	expected := []string{
-		"tcp://incproc1",
-		"tcp://inproc2",
-	}
-
-	for i, expect := range expected {
-		if endpoints[i] != expect {
-			t.Errorf("expected endpoint '%s', got '%s'", expect[i], endpoints[i])
-		}
-	}
-}
-
 func TestNew(t *testing.T) {
 	endpoints := []string{"inproc://test1"}
 	topics := []string{"topic1", "topic2"}


### PR DESCRIPTION
Initially I wrote logtalez to accept a list of hosts, and a list of program names as arguments.  It would then construct a list of topics by combining these together.  It made the assumption that the user would be creating an rsyslog template for the output that used "hostname.programname" as the topic.

At the time I believed this would make logtalez simpler to use.  In practice, it has turned out to be overly complex and solving a problem that didn't exist.

This PR changes logtalez to accept a simple comma delimited list of subscription topics instead.  This makes it simpler to use - especially in conjunction with recent omczmq changes for rsyslog that allow static topic definitions for an output in addition to using templates to construct topics.