### PR TITLE
Problem: want ability to use ephemeral certs

### DIFF
--- a/cmd/logtalez/main.go
+++ b/cmd/logtalez/main.go
@@ -37,8 +37,10 @@ func main() {
 		log.Fatalf("error reading server certificate %q: %s", *serverCertPathPtr, err)
 	}
 
-	if _, err := os.Stat(*clientCertPathPtr); err != nil {
-		log.Fatalf("error reading client certificate %q: %s", *clientCertPathPtr, err)
+	if *clientCertPathPtr != "*" {
+		if _, err := os.Stat(*clientCertPathPtr); err != nil {
+			log.Fatalf("error reading client certificate %q: %s", *clientCertPathPtr, err)
+		}
 	}
 
 	topicList := make([]string, 0)

--- a/logtalez.go
+++ b/logtalez.go
@@ -30,9 +30,13 @@ func New(endpoints, topics []string, serverCertPath, clientCertPath string) (*Lo
 		return lt, err
 	}
 
-	lt.clientCert, err = goczmq.NewCertFromFile(clientCertPath)
-	if err != nil {
-		return lt, err
+	if clientCertPath == "*" {
+		lt.clientCert = goczmq.NewCert()
+	} else {
+		lt.clientCert, err = goczmq.NewCertFromFile(clientCertPath)
+		if err != nil {
+			return lt, err
+		}
 	}
 
 	lt.sock = goczmq.NewSock(goczmq.Sub)


### PR DESCRIPTION
Solution: passing '*' for client certificate path will tell logtalez to generate an ephemeral cert.